### PR TITLE
Refactor/prepare create events firestore integration

### DIFF
--- a/app/src/main/java/com/example/a310_rondayview/Event.java
+++ b/app/src/main/java/com/example/a310_rondayview/Event.java
@@ -1,8 +1,5 @@
 package com.example.a310_rondayview;
 
-
-import com.google.firebase.Timestamp;
-
 import java.util.Date;
 
 public class Event {
@@ -26,7 +23,7 @@ public class Event {
         return location;
     }
 
-    public Timestamp getDateTime() {
+    public Date getDateTime() {
         return dateTime;
     }
 
@@ -43,7 +40,7 @@ public class Event {
     private String title;
     private String description;
     private String location;
-    private Timestamp dateTime; // firestore default timestamp
+    private Date dateTime; // firestore default timestamp
     private String imageURL;
     private String eventClubProfilePicture;
 
@@ -51,7 +48,7 @@ public class Event {
         // Default constructor for Firestore deserialization
     }
 
-    public Event(String eventID, String clubName, String title, String description, String location, Timestamp dateTime, String imageURL, String eventClubProfilePicture) {
+    public Event(String eventID, String clubName, String title, String description, String location, Date dateTime, String imageURL, String eventClubProfilePicture) {
         this.eventID = eventID;
         this.clubName = clubName;
         this.title = title;
@@ -61,9 +58,4 @@ public class Event {
         this.imageURL = imageURL;
         this.eventClubProfilePicture = eventClubProfilePicture;
     }
-
-    void updateDetails(){}
-    void delete(){}
-
-
 }

--- a/app/src/main/java/com/example/a310_rondayview/Event.java
+++ b/app/src/main/java/com/example/a310_rondayview/Event.java
@@ -7,7 +7,7 @@ import java.util.Date;
 public class Event {
 
     @DocumentId
-    private String eventID;
+    private String eventId;
     private String clubName;
     private String title;
     private String description;
@@ -20,8 +20,8 @@ public class Event {
         // Default constructor for Firestore deserialization
     }
 
-    public Event(String eventID, String clubName, String title, String description, String location, Date dateTime, String imageURL, String eventClubProfilePicture) {
-        this.eventID = eventID;
+    public Event(String eventId, String clubName, String title, String description, String location, Date dateTime, String imageURL, String eventClubProfilePicture) {
+        this.eventId = eventId;
         this.clubName = clubName;
         this.title = title;
         this.description = description;
@@ -31,8 +31,8 @@ public class Event {
         this.eventClubProfilePicture = eventClubProfilePicture;
     }
 
-    public String getEventID() {
-        return eventID;
+    public String getEventId() {
+        return eventId;
     }
 
     public String getClubName() {

--- a/app/src/main/java/com/example/a310_rondayview/Event.java
+++ b/app/src/main/java/com/example/a310_rondayview/Event.java
@@ -1,15 +1,18 @@
 package com.example.a310_rondayview;
 
+import com.google.firebase.firestore.DocumentId;
+
 import java.util.Date;
 
 public class Event {
 
+    @DocumentId
     private String eventID;
     private String clubName;
     private String title;
     private String description;
     private String location;
-    private Date dateTime; // firestore default timestamp
+    private Date dateTime;
     private String imageURL;
     private String eventClubProfilePicture;
 

--- a/app/src/main/java/com/example/a310_rondayview/Event.java
+++ b/app/src/main/java/com/example/a310_rondayview/Event.java
@@ -3,6 +3,31 @@ package com.example.a310_rondayview;
 import java.util.Date;
 
 public class Event {
+
+    private String eventID;
+    private String clubName;
+    private String title;
+    private String description;
+    private String location;
+    private Date dateTime; // firestore default timestamp
+    private String imageURL;
+    private String eventClubProfilePicture;
+
+    public Event() {
+        // Default constructor for Firestore deserialization
+    }
+
+    public Event(String eventID, String clubName, String title, String description, String location, Date dateTime, String imageURL, String eventClubProfilePicture) {
+        this.eventID = eventID;
+        this.clubName = clubName;
+        this.title = title;
+        this.description = description;
+        this.location = location;
+        this.dateTime = dateTime;
+        this.imageURL = imageURL;
+        this.eventClubProfilePicture = eventClubProfilePicture;
+    }
+
     public String getEventID() {
         return eventID;
     }
@@ -33,29 +58,5 @@ public class Event {
 
     public String getEventClubProfilePicture() {
         return eventClubProfilePicture;
-    }
-
-    private String eventID;
-    private String clubName;
-    private String title;
-    private String description;
-    private String location;
-    private Date dateTime; // firestore default timestamp
-    private String imageURL;
-    private String eventClubProfilePicture;
-
-    public Event() {
-        // Default constructor for Firestore deserialization
-    }
-
-    public Event(String eventID, String clubName, String title, String description, String location, Date dateTime, String imageURL, String eventClubProfilePicture) {
-        this.eventID = eventID;
-        this.clubName = clubName;
-        this.title = title;
-        this.description = description;
-        this.location = location;
-        this.dateTime = dateTime;
-        this.imageURL = imageURL;
-        this.eventClubProfilePicture = eventClubProfilePicture;
     }
 }

--- a/app/src/main/java/com/example/a310_rondayview/FragmentHome.java
+++ b/app/src/main/java/com/example/a310_rondayview/FragmentHome.java
@@ -92,7 +92,7 @@ public class FragmentHome extends Fragment {
 
             // Format the date and time as a single string
             SimpleDateFormat dateTimeFormat = new SimpleDateFormat("d' 'MMMM yyyy, hh:mm a");
-            String dateTimeString = dateTimeFormat.format(event.getDateTime().toDate());
+            String dateTimeString = dateTimeFormat.format(event.getDateTime());
 
             // Set the formatted date and time in the UI
             timeTextView.setText(dateTimeString);


### PR DESCRIPTION
Minor changes to Event class to make creating events easier.
- Changed `dateTime` field type from `Timestamp` to `Date`
- Added `@DocumentId` annotation to `eventId` so Firestore automatically populates it when getting events
    - Deleted `eventId` field from the documents in Firestore (as a result code without the Event class change will **no longer work**)

Prepares for #40 