### PR TITLE
hotfix: use currentEventIndex instead of index passed in by koloda

### DIFF
--- a/app/src/main/java/com/example/a310_rondayview/FragmentHome.java
+++ b/app/src/main/java/com/example/a310_rondayview/FragmentHome.java
@@ -58,12 +58,12 @@ public class FragmentHome extends Fragment {
 
             @Override
             public void onCardSwipedLeft(int i) {
-                handleSwipe(false, i);
+                handleSwipe(false, currentEventIndex);
             }
 
             @Override
             public void onCardSwipedRight(int i) {
-               handleSwipe(true, i);
+               handleSwipe(true, currentEventIndex);
             }
 
             @Override


### PR DESCRIPTION
Use `currentEventIndex` instead of index `i` passed into the Koloda listener as it gives first index as `-1`.
Resolves #61 (but bit hacky)